### PR TITLE
add async call tracker and takeLatest tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2936,9 +2936,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz",
+      "integrity": "sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -3077,15 +3077,24 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.3.tgz",
+      "integrity": "sha512-Ytgnz23gm2DVftnzqRRz2dOXZbGd2uiajSw/95bPp6v53zPRspQjLm/AfBgqbJ2qfeRXWIOMVLpp86+/5yX39Q==",
       "dev": true,
       "requires": {
-        "agent-base": "^4.1.0",
+        "agent-base": "^4.3.0",
         "debug": "^3.1.0"
       },
       "dependencies": {
+        "agent-base": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "dev": true,
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -3096,9 +3105,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -5985,20 +5994,20 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.3.tgz",
+      "integrity": "sha512-KfQUgOqTkLp2aZxrMbCuKCDGW9slFYu2A23A36Gs7sGzTLcRBDORdOi5E21KWHFIfkY8kzgi/Pr1cXCh0yIp5g==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.20.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true,
           "optional": true
         },

--- a/packages/dispatch-react/package-lock.json
+++ b/packages/dispatch-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-dispatch-react",
-  "version": "0.2.3",
+  "version": "0.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -32,19 +32,12 @@
       "integrity": "sha512-YlMV1kTKnBuMXC2EA9lBxyPD7I4GSz3o8qJe9DdZlaHwZXG8vGW7yoZOoouPv7s7cUTX0kYa39awsiAK3knAqg=="
     },
     "hydra-dispatch": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/hydra-dispatch/-/hydra-dispatch-0.1.1.tgz",
-      "integrity": "sha512-YdgSTMXIHZrmRbVD2LnUn02gS6kySwED2qpCnNJtTLN1n4db9KZVhbKldi5AzHPiSEq/Bkn2gFy/OukhsYTcwg==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/hydra-dispatch/-/hydra-dispatch-0.2.7.tgz",
+      "integrity": "sha512-3vyt+5qATQO59VV0wd45ndyoP2YvlaJp7UN6LPQQZdqc7EpAoR1iSOuV2/MXMia/ADSKGklxk3iKbpaj9uCr3A==",
       "requires": {
-        "functools-ts": "^0.1.0",
+        "functools-ts": "^0.2.0",
         "rxjs": "^6.4.0"
-      },
-      "dependencies": {
-        "functools-ts": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/functools-ts/-/functools-ts-0.1.1.tgz",
-          "integrity": "sha512-I52p91WZXkf+A/ruVMBLCfqVCzJKGOfRODvXDcyLHWI6XTc0dIel5w+1tJv4on0dhpiOt0xqhZzs6b4AVg+Upg=="
-        }
       }
     },
     "js-tokens": {
@@ -92,9 +85,9 @@
       "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
     },
     "rxjs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
-      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
       "requires": {
         "tslib": "^1.9.0"
       }

--- a/packages/dispatch-react/package.json
+++ b/packages/dispatch-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-dispatch-react",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {

--- a/packages/dispatch-react/package.json
+++ b/packages/dispatch-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-dispatch-react",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {
@@ -10,7 +10,7 @@
   "dependencies": {
     "react": "^16.8.6",
     "functools-ts": "^0.2.0",
-    "hydra-dispatch": "0.2.6"
+    "hydra-dispatch": "0.2.7"
   },
   "devDependencies": {
     "@types/react": "^16.8.5",

--- a/packages/dispatch-react/package.json
+++ b/packages/dispatch-react/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "react": "^16.8.6",
     "functools-ts": "^0.2.0",
-    "hydra-dispatch": "0.2.7"
+    "hydra-dispatch": "0.2.8"
   },
   "devDependencies": {
     "@types/react": "^16.8.5",

--- a/packages/dispatch-redux/index.ts
+++ b/packages/dispatch-redux/index.ts
@@ -78,11 +78,11 @@ export const dispatcherFromRedux = <S>(
   reduxDispatch: ReduxDispatch
 ): Dispatch<S> => {
   let tracker = asyncCallTracker()
-  let dispatch = ((update: UpdateFn<S>, opts: DispatchOpts) => {
+  let dispatch = ((update: UpdateFn<S>, opts?: DispatchOpts) => {
     const action = Schedule(update, tracker, {
-      tag: opts.tag || update.tag || "SetState",
-      noReplay: opts.noReplay || update.noReplay || false,
-      takeLatest: opts.takeLatest && opts.tag ? true : false
+      tag: opts && opts.tag || update.tag || "SetState",
+      noReplay: opts && opts.noReplay || update.noReplay || false,
+      takeLatest: opts && opts.takeLatest && opts.tag ? true : false
     })
     reduxDispatch(action as any)
   }) as Dispatch<S>

--- a/packages/dispatch-redux/index.ts
+++ b/packages/dispatch-redux/index.ts
@@ -1,4 +1,4 @@
-import {UpdateFn, isPromise, Dispatch, DispatchSymbol} from "hydra-dispatch"
+import {UpdateFn, isPromise, Dispatch, DispatchSymbol, DispatchOpts, AsyncCallTracker, asyncCallTracker} from "hydra-dispatch"
 import {Action, Dispatch as ReduxDispatch} from "redux"
 import {isObservable} from "rxjs"
 
@@ -44,22 +44,31 @@ export const updateStateReducer = <S, A extends Action>(
 
 const Schedule = <S>(
   update: UpdateFn<S>,
-  name?: string,
-  noReplay?: boolean
+  tracker: AsyncCallTracker,
+  opts: DispatchOpts
 ) => (dispatch: ReduxDispatch, getState: () => S) => {
   const state = getState()
   try {
     const cont = update(state)
     if (isPromise(cont)) {
-      cont
-        .then(pupdate => dispatch(Schedule(pupdate, name, noReplay) as any))
-        .catch(err => dispatch(GotError(err)))
+      if (opts.tag && opts.takeLatest) {
+        const timestamp = tracker.record(opts.tag)
+        cont.then(pupdate => {
+          const latestRecorded = tracker.latestTimestampRecorded(opts.tag!)
+          if (latestRecorded === timestamp)
+            dispatch(Schedule(pupdate, tracker, opts) as any)
+        })
+      } else {
+        cont
+          .then(pupdate => dispatch(Schedule(pupdate, tracker, opts) as any))
+          .catch(err => dispatch(GotError(err)))
+      }
     } else if (isObservable(cont)) {
       cont.subscribe(
-        pupdate => dispatch(Schedule(pupdate, name, noReplay) as any),
+        pupdate => dispatch(Schedule(pupdate, tracker, opts) as any),
         err => dispatch(GotError(err))
       )
-    } else dispatch(SetState(cont, name, noReplay))
+    } else dispatch(SetState(cont, opts.tag, opts.noReplay))
   } catch (err) {
     dispatch(GotError(err))
   }
@@ -68,8 +77,13 @@ const Schedule = <S>(
 export const dispatcherFromRedux = <S>(
   reduxDispatch: ReduxDispatch
 ): Dispatch<S> => {
-  let dispatch = ((update: UpdateFn<S>, name?: string, noReplay?: boolean) => {
-    const action = Schedule(update, name || update.name || "SetState" , noReplay ? true : false)
+  let tracker = asyncCallTracker()
+  let dispatch = ((update: UpdateFn<S>, opts: DispatchOpts) => {
+    const action = Schedule(update, tracker, {
+      tag: opts.tag || update.tag || "SetState",
+      noReplay: opts.noReplay || update.noReplay || false,
+      takeLatest: opts.takeLatest && opts.tag ? true : false
+    })
     reduxDispatch(action as any)
   }) as Dispatch<S>
   dispatch[DispatchSymbol] = true

--- a/packages/dispatch-redux/package-lock.json
+++ b/packages/dispatch-redux/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-dispatch-redux",
-  "version": "0.2.3",
+  "version": "0.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,16 +14,16 @@
       }
     },
     "functools-ts": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/functools-ts/-/functools-ts-0.1.1.tgz",
-      "integrity": "sha512-I52p91WZXkf+A/ruVMBLCfqVCzJKGOfRODvXDcyLHWI6XTc0dIel5w+1tJv4on0dhpiOt0xqhZzs6b4AVg+Upg=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/functools-ts/-/functools-ts-0.2.0.tgz",
+      "integrity": "sha512-YlMV1kTKnBuMXC2EA9lBxyPD7I4GSz3o8qJe9DdZlaHwZXG8vGW7yoZOoouPv7s7cUTX0kYa39awsiAK3knAqg=="
     },
     "hydra-dispatch": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/hydra-dispatch/-/hydra-dispatch-0.1.1.tgz",
-      "integrity": "sha512-YdgSTMXIHZrmRbVD2LnUn02gS6kySwED2qpCnNJtTLN1n4db9KZVhbKldi5AzHPiSEq/Bkn2gFy/OukhsYTcwg==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/hydra-dispatch/-/hydra-dispatch-0.2.7.tgz",
+      "integrity": "sha512-3vyt+5qATQO59VV0wd45ndyoP2YvlaJp7UN6LPQQZdqc7EpAoR1iSOuV2/MXMia/ADSKGklxk3iKbpaj9uCr3A==",
       "requires": {
-        "functools-ts": "^0.1.0",
+        "functools-ts": "^0.2.0",
         "rxjs": "^6.4.0"
       }
     },
@@ -55,9 +55,9 @@
       "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
     },
     "rxjs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
-      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
       "requires": {
         "tslib": "^1.9.0"
       }

--- a/packages/dispatch-redux/package.json
+++ b/packages/dispatch-redux/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "redux": "^4.0.1",
     "redux-thunk": "^2.3.0",
-    "hydra-dispatch": "0.2.7"
+    "hydra-dispatch": "0.2.8"
   },
   "devDependencies": {
     "@types/redux": "3.6.0",

--- a/packages/dispatch-redux/package.json
+++ b/packages/dispatch-redux/package.json
@@ -3,7 +3,7 @@
   "description": "Redux support for hydra-dispatch",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "scripts": {
     "prepare": "npm run build",
     "build": "tsc --outDir dist"

--- a/packages/dispatch-redux/package.json
+++ b/packages/dispatch-redux/package.json
@@ -3,7 +3,7 @@
   "description": "Redux support for hydra-dispatch",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "scripts": {
     "prepare": "npm run build",
     "build": "tsc --outDir dist"
@@ -11,7 +11,7 @@
   "dependencies": {
     "redux": "^4.0.1",
     "redux-thunk": "^2.3.0",
-    "hydra-dispatch": "0.2.6"
+    "hydra-dispatch": "0.2.7"
   },
   "devDependencies": {
     "@types/redux": "3.6.0",

--- a/packages/dispatch/package.json
+++ b/packages/dispatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-dispatch",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {

--- a/packages/dispatch/package.json
+++ b/packages/dispatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-dispatch",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
This PR add an async call tracker and allow user to specify if they are only interested into the last async update.

The scheduler will ignore if the timestamp are not the same as registered(means a new async update has been passed)